### PR TITLE
Setup python module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.test = [ "coverage" ]
 urls."Source" = "https://github.com/max-models/slurm-script-generator"
-scripts.generate-slurm-script = "slurm_script_generator.main:main"
+scripts.generate-slurm-script = "slurm_script_generator.main:generate_script"
 
 [tool.setuptools.packages.find]
 where = [ "src" ]

--- a/src/slurm_script_generator/main.py
+++ b/src/slurm_script_generator/main.py
@@ -111,7 +111,7 @@ def read_yaml(path):
         return json.load(f)
 
 
-def generate_script(sbatch_args):
+def generate_script(sbatch_args) -> str:
 
     slurm_options_dict = sbatch.get_slurm_options_dict()
 
@@ -223,8 +223,8 @@ def generate_script(sbatch_args):
     if args_dict.get("output") is not None:
         with open(args_dict.get("output"), "w") as f:
             f.write(script)
-    else:
-        print(script)
+
+    return script
 
 
 def main():
@@ -237,7 +237,9 @@ def main():
     add_misc_options(parser=parser)
     sbatch_args = parser.parse_args()
 
-    generate_script(sbatch_args=sbatch_args)
+    script = generate_script(sbatch_args=sbatch_args)
+
+    print(script)
 
 
 if __name__ == "__main__":

--- a/src/slurm_script_generator/main.py
+++ b/src/slurm_script_generator/main.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 
-import slurm_script_generator.sbatch_parser as sbatch_parser
+import slurm_script_generator.sbatch as sbatch
 
 
 def add_misc_options(parser):
@@ -111,21 +111,9 @@ def read_yaml(path):
         return json.load(f)
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Slurm job submission options",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+def generate_script(sbatch_args):
 
-    sbatch_parser.add_slurm_options(parser=parser)
-
-    slurm_options_dict = {}
-    for action in parser._actions:
-        slurm_options_dict[action.dest] = action.help
-
-    add_misc_options(parser=parser)
-
-    sbatch_args = parser.parse_args()
+    slurm_options_dict = sbatch.get_slurm_options_dict()
 
     if sbatch_args.input is not None:
         args_dict = read_yaml(sbatch_args.input)
@@ -237,3 +225,20 @@ def main():
             f.write(script)
     else:
         print(script)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Slurm job submission options",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    sbatch.add_slurm_options(parser=parser)
+    add_misc_options(parser=parser)
+    sbatch_args = parser.parse_args()
+
+    generate_script(sbatch_args=sbatch_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/slurm_script_generator/main.py
+++ b/src/slurm_script_generator/main.py
@@ -111,20 +111,9 @@ def read_yaml(path):
         return json.load(f)
 
 
-def generate_script(sbatch_args) -> str:
+def generate_script(args_dict) -> str:
 
     slurm_options_dict = sbatch.get_slurm_options_dict()
-
-    if sbatch_args.input is not None:
-        args_dict = read_yaml(sbatch_args.input)
-    else:
-        args_dict = {}
-    for arg in sbatch_args.__dict__:
-        val = sbatch_args.__dict__[arg]
-        if val is not None and val is not False:
-            if isinstance(val, list) and len(val) == 0:
-                continue
-            args_dict.update({arg: val})
 
     line_length = args_dict.get("line_length", 60)
 
@@ -237,7 +226,18 @@ def main():
     add_misc_options(parser=parser)
     sbatch_args = parser.parse_args()
 
-    script = generate_script(sbatch_args=sbatch_args)
+    if sbatch_args.input is not None:
+        args_dict = read_yaml(sbatch_args.input)
+    else:
+        args_dict = {}
+    for arg in sbatch_args.__dict__:
+        val = sbatch_args.__dict__[arg]
+        if val is not None and val is not False:
+            if isinstance(val, list) and len(val) == 0:
+                continue
+            args_dict.update({arg: val})
+
+    script = generate_script(args_dict=args_dict)
 
     print(script)
 

--- a/src/slurm_script_generator/sbatch.py
+++ b/src/slurm_script_generator/sbatch.py
@@ -578,3 +578,16 @@ def add_slurm_options(parser):
         dest="nvmps",
         help="launching NVIDIA MPS for job",
     )
+
+
+def get_slurm_options_dict():
+    _parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_slurm_options(parser=_parser)
+
+    slurm_options_dict = {}
+    for action in _parser._actions:
+        slurm_options_dict[action.dest] = action.help
+
+    return slurm_options_dict

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -7,9 +7,13 @@ def test_import_app():
 def test_options():
     from slurm_script_generator.main import generate_script
 
-    args = {}
-    generate_script(sbatch_args=args)
+    args = {"nodes": 1, "ntasks_per_node": 16}
+    script = generate_script(args_dict=args)
+    assert "#SBATCH --nodes 1" in script
+    assert "#SBATCH --ntasks_per_node 16" in script
+    print(script)
 
 
 if __name__ == "__main__":
     test_import_app()
+    test_options()

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -4,5 +4,12 @@ def test_import_app():
     print("slurm_script_generator imported")
 
 
+def test_options():
+    from slurm_script_generator.main import generate_script
+
+    args = {}
+    generate_script(sbatch_args=args)
+
+
 if __name__ == "__main__":
     test_import_app()


### PR DESCRIPTION
The scripts can now be generated in python, tested like this:

```python
def test_options():
    from slurm_script_generator.main import generate_script

    args = {"nodes": 1, "ntasks_per_node": 16}
    script = generate_script(args_dict=args)
    assert "#SBATCH --nodes 1" in script
    assert "#SBATCH --ntasks_per_node 16" in script
    print(script)
```