### PR TITLE
42 add a header

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ generate-slurm-script --nodes 1 --ntasks-per-node 16
 ```
 
     #!/bin/bash
+    ########################################################
+    #            This script was generated using           #
+    #             slurm-script-generator v0.3.0            #
+    # https://github.com/max-models/slurm-script-generator #
+    #      `pip install slurm-script-generator==0.3.0`     #
+    ########################################################
+
     ##########################################
     #SBATCH --nodes=1                        # number of nodes on which to run
     #SBATCH --ntasks-per-node=16             # number of tasks to invoke on each node
@@ -24,6 +31,18 @@ To save the script to file `my_script.sh` use `--output`:
 ``` bash
 generate-slurm-script --nodes 1 --ntasks-per-node 16 --output my_script.sh
 ```
+
+Remove the header comment with `--no-header`:
+
+``` bash
+generate-slurm-script --nodes 1 --ntasks-per-node 16 --no-header
+```
+
+    #!/bin/bash
+    ##########################################
+    #SBATCH --nodes=1                        # number of nodes on which to run
+    #SBATCH --ntasks-per-node=16             # number of tasks to invoke on each node
+    ##########################################
 
 You can also generate scripts in Python programmatically:
 
@@ -43,6 +62,13 @@ print(slurm_script)
 ```
 
     #!/bin/bash
+    ########################################################
+    #            This script was generated using           #
+    #             slurm-script-generator v0.3.0            #
+    # https://github.com/max-models/slurm-script-generator #
+    #      `pip install slurm-script-generator==0.3.0`     #
+    ########################################################
+
     ##########################################
     #SBATCH --nodes=2                        # number of nodes on which to run
     #SBATCH --ntasks-per-core=16             # number of tasks to invoke on each core
@@ -60,7 +86,7 @@ script = slurm_script.generate_script()
 To export the settings to a json file you can use `--export-json`:
 
 ``` bash
-generate-slurm-script --nodes 2 --export-json setup.json
+generate-slurm-script --nodes 2 --export-json setup.json --no-header
 ```
 
     #!/bin/bash
@@ -71,7 +97,7 @@ generate-slurm-script --nodes 2 --export-json setup.json
 This json file can used as a basis for creating new scripts
 
 ``` bash
-generate-slurm-script --input setup.json --ntasks-per-node 16
+generate-slurm-script --input setup.json --ntasks-per-node 16 --no-header
 ```
 
     #!/bin/bash
@@ -85,7 +111,7 @@ generate-slurm-script --input setup.json --ntasks-per-node 16
 Add modules with
 
 ``` bash
-generate-slurm-script --input setup.json --ntasks-per-node 16 --modules gcc/13 openmpi/5.0
+generate-slurm-script --input setup.json --ntasks-per-node 16 --modules gcc/13 openmpi/5.0 --no-header
 ```
 
     #!/bin/bash
@@ -148,6 +174,7 @@ generate-slurm-script -h
                                  [--custom-commands COMMAND [COMMAND ...]]
                                  [--inline-script COMMAND]
                                  [--inline-scripts COMMAND [COMMAND ...]]
+                                 [--no-header]
 
     Slurm job submission options
 
@@ -317,3 +344,5 @@ generate-slurm-script -h
       --inline-scripts COMMAND [COMMAND ...]
                             Add inline scripts at the end of the script (e.g.
                             --inline-scripts script1.sh script2.sh) (default: [])
+      --no-header           Do not include the header comment in the generated
+                            script (default: False)

--- a/README.qmd
+++ b/README.qmd
@@ -24,6 +24,12 @@ To save the script to file `my_script.sh` use `--output`:
 generate-slurm-script --nodes 1 --ntasks-per-node 16 --output my_script.sh
 ```
 
+Remove the header comment with `--no-header`:
+
+```{bash}
+generate-slurm-script --nodes 1 --ntasks-per-node 16 --no-header
+```
+
 You can also generate scripts in Python programmatically:
 
 ```{python}
@@ -50,13 +56,13 @@ script = slurm_script.generate_script()
 To export the settings to a json file you can use `--export-json`:
 
 ```{bash}
-generate-slurm-script --nodes 2 --export-json setup.json
+generate-slurm-script --nodes 2 --export-json setup.json --no-header
 ```
 
 This json file can used as a basis for creating new scripts
 
 ```{bash}
-generate-slurm-script --input setup.json --ntasks-per-node 16
+generate-slurm-script --input setup.json --ntasks-per-node 16 --no-header
 ```
 
 ### Add modules
@@ -64,7 +70,7 @@ generate-slurm-script --input setup.json --ntasks-per-node 16
 Add modules with
 
 ```{bash}
-generate-slurm-script --input setup.json --ntasks-per-node 16 --modules gcc/13 openmpi/5.0
+generate-slurm-script --input setup.json --ntasks-per-node 16 --modules gcc/13 openmpi/5.0 --no-header
 ```
 
 ### Other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "slurm-script-generator"
-version = "0.2.1"
+version = "0.3.0"
 description = "Generate slurm scripts."
 readme = "README.md"
 keywords = [ "python" ]
@@ -15,10 +15,6 @@ requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]

--- a/src/slurm_script_generator/main.py
+++ b/src/slurm_script_generator/main.py
@@ -92,6 +92,14 @@ def add_misc_options(parser: argparse.ArgumentParser) -> None:
         help="Add inline scripts at the end of the script (e.g. --inline-scripts script1.sh script2.sh)",
     )
 
+    parser.add_argument(
+        "--no-header",
+        dest="no_header",
+        action="store_true",
+        default=False,
+        help="Do not include the header comment in the generated script",
+    )
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -144,6 +152,10 @@ def main():
     delattr(sbatch_args, "input")
     delattr(sbatch_args, "output")
 
+    # Extract the no_header flag
+    no_header = sbatch_args.no_header
+    delattr(sbatch_args, "no_header")
+
     # If a JSON input path is provided, load the SlurmScript from that JSON file.
     # Otherwise, create a new SlurmScript instance.
     if path_json_in is not None:
@@ -175,9 +187,9 @@ def main():
 
     if path_out:
         with open(path_out, "w") as f:
-            f.write(str(slurm_script))
+            f.write(slurm_script.generate_script(include_header=not no_header))
     else:
-        print(slurm_script)
+        print(slurm_script.to_string(include_header=not no_header))
 
 
 if __name__ == "__main__":

--- a/src/slurm_script_generator/slurm_script.py
+++ b/src/slurm_script_generator/slurm_script.py
@@ -350,7 +350,7 @@ class SlurmScript:
         return self.generate_script(include_header=include_header)
 
     def __str__(self) -> str:
-        return self.generate_script(include_header=True)
+        return self.to_string(include_header=True)
 
     @property
     def line_length(self) -> int:

--- a/src/slurm_script_generator/slurm_script.py
+++ b/src/slurm_script_generator/slurm_script.py
@@ -1,8 +1,7 @@
 import json
 import os
-from importlib.metadata import version
 from typing import Any, List
-
+from importlib.metadata import version
 from slurm_script_generator.pragmas import Pragma, PragmaFactory
 from slurm_script_generator.utils import add_line
 
@@ -254,40 +253,42 @@ class SlurmScript:
         else:
             raise ValueError(f"Unknown parameter key: {key}")
 
-    def generate_script(self, line_length: int = 40) -> str:
+    def generate_script(self, line_length: int = 40, include_header: bool = False) -> str:
 
-        script_repr = "#!/bin/bash\n"
+        script_str = "#!/bin/bash\n"
 
         # Add header
-        SLURM_SCRIPT_HEADER = f"""########################################################
+        SLURM_SCRIPT_HEADER = \
+f"""########################################################
 #            This script was generated using           #
 #             slurm-script-generator v{version('slurm-script-generator')}            #
 # https://github.com/max-models/slurm-script-generator #
 #      `pip install slurm-script-generator=={version('slurm-script-generator')}`     #
 ########################################################\n
 """
-        script_repr += SLURM_SCRIPT_HEADER
+        if include_header:
+            script_str += SLURM_SCRIPT_HEADER
 
         # Add sbatch pragmas
         line_separator = "#" * (line_length + 2) + "\n"
-        script_repr += add_line(line_separator)
+        script_str += add_line(line_separator)
         for pragma in self.pragmas:
-            script_repr += f"{pragma}"
-        script_repr += add_line(line_separator)
+            script_str += f"{pragma}"
+        script_str += add_line(line_separator)
 
         # Load modules
         if len(self.modules) > 0:
-            script_repr += add_line(
+            script_str += add_line(
                 "module purge",
                 "Purge modules",
                 line_length=line_length,
             )
-            script_repr += add_line(
+            script_str += add_line(
                 f"module load {' '.join(self.modules)}",
                 "modules",
                 line_length=line_length,
             )
-            script_repr += add_line(
+            script_str += add_line(
                 "module list",
                 "List loaded modules",
                 line_length=line_length,
@@ -295,12 +296,12 @@ class SlurmScript:
 
         if len(self.custom_commands) > 0:
             for custom_command in self.custom_commands:
-                script_repr += add_line(
+                script_str += add_line(
                     f"{custom_command}\n",
                     line_length=line_length,
                 )
 
-        return script_repr
+        return script_str
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/src/slurm_script_generator/slurm_script.py
+++ b/src/slurm_script_generator/slurm_script.py
@@ -1,7 +1,8 @@
 import json
 import os
-from typing import Any, List
 from importlib.metadata import version
+from typing import Any, List
+
 from slurm_script_generator.pragmas import Pragma, PragmaFactory
 from slurm_script_generator.utils import add_line
 
@@ -253,13 +254,14 @@ class SlurmScript:
         else:
             raise ValueError(f"Unknown parameter key: {key}")
 
-    def generate_script(self, line_length: int = 40, include_header: bool = False) -> str:
+    def generate_script(
+        self, line_length: int = 40, include_header: bool = False
+    ) -> str:
 
         script_str = "#!/bin/bash\n"
 
         # Add header
-        SLURM_SCRIPT_HEADER = \
-f"""########################################################
+        SLURM_SCRIPT_HEADER = f"""########################################################
 #            This script was generated using           #
 #             slurm-script-generator v{version('slurm-script-generator')}            #
 # https://github.com/max-models/slurm-script-generator #
@@ -344,8 +346,11 @@ f"""########################################################
             return False
         return self.to_dict() == value.to_dict()
 
+    def to_string(self, include_header: bool = True) -> str:
+        return self.generate_script(include_header=include_header)
+
     def __str__(self) -> str:
-        return self.generate_script()
+        return self.generate_script(include_header=True)
 
     @property
     def line_length(self) -> int:

--- a/src/slurm_script_generator/slurm_script.py
+++ b/src/slurm_script_generator/slurm_script.py
@@ -1,5 +1,6 @@
 import json
 import os
+from importlib.metadata import version
 from typing import Any, List
 
 from slurm_script_generator.pragmas import Pragma, PragmaFactory
@@ -254,11 +255,25 @@ class SlurmScript:
             raise ValueError(f"Unknown parameter key: {key}")
 
     def generate_script(self, line_length: int = 40) -> str:
+
         script_repr = "#!/bin/bash\n"
-        script_repr += "#" * (line_length + 2) + "\n"
+
+        # Add header
+        SLURM_SCRIPT_HEADER = f"""########################################################
+#            This script was generated using           #
+#             slurm-script-generator v{version('slurm-script-generator')}            #
+# https://github.com/max-models/slurm-script-generator #
+#      `pip install slurm-script-generator=={version('slurm-script-generator')}`     #
+########################################################\n
+"""
+        script_repr += SLURM_SCRIPT_HEADER
+
+        # Add sbatch pragmas
+        line_separator = "#" * (line_length + 2) + "\n"
+        script_repr += add_line(line_separator)
         for pragma in self.pragmas:
             script_repr += f"{pragma}"
-        script_repr += "#" * (line_length + 2) + "\n"
+        script_repr += add_line(line_separator)
 
         # Load modules
         if len(self.modules) > 0:


### PR DESCRIPTION
Added this kind of header by default:

```bash
#!/bin/bash
########################################################
#            This script was generated using           #
#             slurm-script-generator v0.3.0            #
# https://github.com/max-models/slurm-script-generator #
#      `pip install slurm-script-generator==0.3.0`     #
########################################################

##########################################
#SBATCH --nodes=2                        # number of nodes on which to run
#SBATCH --ntasks-per-core=16             # number of tasks to invoke on each core
##########################################
# Run simulation
srun ./bin > run.out
```

It can be suppressed with `--no-header`